### PR TITLE
Slic3r fix and Perl improvements

### DIFF
--- a/velPaint
+++ b/velPaint
@@ -93,6 +93,10 @@ while (my $line = <>) {
 	 $line =~ /G1 X([^\s]+) Y([^\s]+) Z([^\s]+) E([^\s]+)$/ unless (defined $x);
 	($x, $y, $e) =
 	 $line =~ /G1 X([^\s]+) Y([^\s]+) E([^\s]+)$/ unless (defined $x);
+	($z, $x, $y, $e, $f) =
+	 $line =~ /G1 Z([^\s]+) X([^\s]+) Y([^\s]+) E([^\s]+) F($targetSpeed)$/;
+	($z, $x, $y, $e) =
+	 $line =~ /G1 Z([^\s]+) X([^\s]+) Y([^\s]+) E([^\s]+)$/ unless (defined $x);
 
 	if (defined $z) { $currentZ = $z } else { $z = $currentZ; }
 

--- a/velPaint
+++ b/velPaint
@@ -4,6 +4,8 @@
 # International License](http://creativecommons.org/licenses/by/4.0/).
 # Based on a work at https://github.com/MarkWheadon/velocity-painting.
 
+use strict;
+use warnings;
 
 our $VERSION = 0.1;
 use Math::Trig;
@@ -75,7 +77,7 @@ if ($projectedImageHeight eq '-') {
 
 my $maxVecLength = .1; # Longest vector in mm. Splits longer vectors. Very small -> long processing times.
 
-my ($oldX, $oldY, $oldZ);
+my ($oldX, $oldY, $oldZ, $oldE);
 my $currentZ;
 my $lastZOutput = -1;
 
@@ -86,23 +88,23 @@ while (my $line = <>) {
 	$line =~ s/\r//g;
 
 	($x, $y, $z, $e, $f) =
-	 $line =~ /G1 X([^\s]+) Y([^\s]+) Z([^\s]+) E([^\s]+) F($targetSpeed)$/;
+	 $line =~ /G1 X(\S+) Y(\S+) Z(\S+) E(\S+) F($targetSpeed)$/;
 	($x, $y, $e, $f) =
-	 $line =~ /G1 X([^\s]+) Y([^\s]+) E([^\s]+) F($targetSpeed)$/ unless (defined $x);
+	 $line =~ /G1 X(\S+) Y(\S+) E(\S+) F($targetSpeed)$/ unless (defined $x);
 	($x, $y, $z, $e) =
-	 $line =~ /G1 X([^\s]+) Y([^\s]+) Z([^\s]+) E([^\s]+)$/ unless (defined $x);
+	 $line =~ /G1 X(\S+) Y(\S+) Z(\S+) E(\S+)$/ unless (defined $x);
 	($x, $y, $e) =
-	 $line =~ /G1 X([^\s]+) Y([^\s]+) E([^\s]+)$/ unless (defined $x);
+	 $line =~ /G1 X(\S+) Y(\S+) E(\S+)$/ unless (defined $x);
 	($z, $x, $y, $e, $f) =
-	 $line =~ /G1 Z([^\s]+) X([^\s]+) Y([^\s]+) E([^\s]+) F($targetSpeed)$/;
+	 $line =~ /G1 Z(\S+) X(\S+) Y(\S+) E(\S+) F($targetSpeed)$/;
 	($z, $x, $y, $e) =
-	 $line =~ /G1 Z([^\s]+) X([^\s]+) Y([^\s]+) E([^\s]+)$/ unless (defined $x);
+	 $line =~ /G1 Z(\S+) X(\S+) Y(\S+) E(\S+)$/ unless (defined $x);
 
 	if (defined $z) { $currentZ = $z } else { $z = $currentZ; }
 
 	if (defined $x) {
 		if (!defined $oldZ) {
-			&outMove($x, $y, $z, $e, 0);
+			outMove($x, $y, $z, $e, 0);
 		} else {
 			my $xd = $x - $oldX;
 			my $yd = $y - $oldY;
@@ -112,10 +114,10 @@ while (my $line = <>) {
 			my $length = sqrt($xd * $xd + $yd * $yd + $zd * $zd);
 
 			if ($length <= $maxVecLength) {
-				&outMove($x, $y, $z, $e, 0);
+				outMove($x, $y, $z, $e, 0);
 			} else {
 				my $lastSegOut = -1;
-				my $oSlow = &surfaceSpeed($oldX, $oldY, $oldZ);
+				my $oSlow = surfaceSpeed($oldX, $oldY, $oldZ);
 
 				my $nSegs = int($length / $maxVecLength + 0.5);
 
@@ -129,11 +131,11 @@ while (my $line = <>) {
 					my $ny = $oldY + $yDelta * $i;
 					my $nz = $oldZ + $zDelta * $i;
 
-					my $slow = &surfaceSpeed($nx, $ny, $nz);
+					my $slow = surfaceSpeed($nx, $ny, $nz);
 
 					if (($slow != $oSlow) && ($i > 1)) {
 						# pattern has changed. Time to output the vector so far
-						&outMove($oldX + $xDelta * ($i - 1),
+						outMove($oldX + $xDelta * ($i - 1),
 						  $oldY + $yDelta * ($i - 1),
 						  $oldZ + $zDelta * ($i - 1),
 						  $oldE + $eDelta * ($i - 1), 1);
@@ -142,16 +144,16 @@ while (my $line = <>) {
 					}
 				}
 				if ($lastSegOut != $nSegs) {
-					&outMove($x, $y, $z, $e);
+					outMove($x, $y, $z, $e);
 				}
 			}
 		}
-		$oldX = $x; $oldY = $y; $oldZ = $z; $oldE = $e;
+        ($oldX, $oldY, $oldZ, $oldE) = ($x, $y, $z, $e);
 	} else {
-		if ($line =~ /G1 X([^\s]+) Y([^\s]+) Z([^\s]+)/) {
-			$oldX = $1; $oldY=$2; $oldZ = $3;
-		} elsif ($line =~ /G1 X([^\s]+) Y([^\s]+)/) {
-			$oldX = $1; $oldY=$2;
+		if ($line =~ /G1 X(\S+) Y(\S+) Z(\S+)/) {
+            ($oldX, $oldY, $oldZ) = ($1, $2, $3);
+		} elsif ($line =~ /G1 X(\S+) Y(\S+)/) {
+            ($oldX, $oldY) = ($1, $2);
 		}
 		if ($line =~ /Z([\d\.]+)/) {
 			$currentZ = $1;
@@ -164,7 +166,7 @@ while (my $line = <>) {
 	}
 }
 
-sub surfaceSpeed() {
+sub surfaceSpeed {
 	if ($projectionMode eq '-cylinderZ') {
 		return surfaceSpeedCylinderZ(@_);
 	} elsif ($projectionMode eq '-projectX') {
@@ -172,7 +174,7 @@ sub surfaceSpeed() {
 	}
 }
 
-sub surfaceSpeedCylinderZ() {
+sub surfaceSpeedCylinderZ {
 	my ($x, $y, $z) = @_;
 
 	my $zNormalized = ($z - $zOffset) / $projectedImageHeight;
@@ -192,7 +194,7 @@ sub surfaceSpeedCylinderZ() {
  	return $lowSpeed + $image->GetPixel(x=>$imageX, y=>$imageY)  * ($highSpeed - $lowSpeed);
 }
 
-sub surfaceSpeedProjectX() {
+sub surfaceSpeedProjectX {
 	my ($x, $y, $z) = @_;
 
 	my $xNormalized = ($x - $printCentreX + $projectedImageWidth / 2) / $projectedImageWidth;
@@ -210,7 +212,7 @@ sub surfaceSpeedProjectX() {
  	return $lowSpeed + $image->GetPixel(x=>$imageX, y=>$imageY)  * ($highSpeed - $lowSpeed);
 }
 
-sub outMove() {
+sub outMove {
 	my ($x, $y, $z, $e, $extra) = @_;
 
 	my $zCommand = "";
@@ -218,6 +220,6 @@ sub outMove() {
 
 	my $added = ""; if ($extra) { $added = " ; added"; }
 
-	printf("G1 X%.3f Y%.3f$zCommand E%.3f F%.3f$added\n", $x, $y, $e, &surfaceSpeed($x, $y, $z));
+	printf("G1 X%.3f Y%.3f$zCommand E%.3f F%.3f$added\n", $x, $y, $e, surfaceSpeed($x, $y, $z));
 	$lastZOutput = $z;
 }

--- a/velPaint
+++ b/velPaint
@@ -57,6 +57,7 @@ my $image = Image::Magick->new;
 my $res = $image->Read($imageFile);
 die "$res" if "$res";
 
+my $speedRange = $highSpeed - $lowSpeed;
 my $imageWidth = $image->Get('columns');;
 my $imageHeight = $image->Get('rows');
 
@@ -148,12 +149,12 @@ while (my $line = <>) {
 				}
 			}
 		}
-        ($oldX, $oldY, $oldZ, $oldE) = ($x, $y, $z, $e);
+		($oldX, $oldY, $oldZ, $oldE) = ($x, $y, $z, $e);
 	} else {
 		if ($line =~ /G1 X(\S+) Y(\S+) Z(\S+)/) {
-            ($oldX, $oldY, $oldZ) = ($1, $2, $3);
+			($oldX, $oldY, $oldZ) = ($1, $2, $3);
 		} elsif ($line =~ /G1 X(\S+) Y(\S+)/) {
-            ($oldX, $oldY) = ($1, $2);
+			($oldX, $oldY) = ($1, $2);
 		}
 		if ($line =~ /Z([\d\.]+)/) {
 			$currentZ = $1;
@@ -174,6 +175,11 @@ sub surfaceSpeed {
 	}
 }
 
+sub outsideImage {
+	my ($imageX, $imageY) = @_;
+	return $imageX < 0 || $imageX >= $imageWidth || $imageY < 0 || $imageY >= $imageHeight;
+}
+
 sub surfaceSpeedCylinderZ {
 	my ($x, $y, $z) = @_;
 
@@ -185,13 +191,13 @@ sub surfaceSpeedCylinderZ {
 	my $imageX = $xNormalized * $imageWidth;
 	my $imageY = $imageHeight - $zNormalized * $imageHeight;
 
-	if ($imageX < 0 || $imageX >= $imageWidth || $imageY < 0 || $imageY >= $imageHeight) {
+	if (outsideImage( $imageX, $imageY )) {
 		return $highSpeed;
 		# return $lowSpeed;
 	}
 
- 	# return $highSpeed - $image->GetPixel(x=>$imageX, y=>$imageY)  * ($highSpeed - $lowSpeed);
- 	return $lowSpeed + $image->GetPixel(x=>$imageX, y=>$imageY)  * ($highSpeed - $lowSpeed);
+ 	# return $highSpeed - $image->GetPixel(x=>$imageX, y=>$imageY)  * $speedRange;
+ 	return $lowSpeed + $image->GetPixel(x=>$imageX, y=>$imageY)  * $speedRange;
 }
 
 sub surfaceSpeedProjectX {
@@ -203,13 +209,13 @@ sub surfaceSpeedProjectX {
 	my $imageX = $xNormalized * $imageWidth;
 	my $imageY = $imageHeight - $zNormalized * $imageHeight;
 
-	if ($imageX < 0 || $imageX >= $imageWidth || $imageY < 0 || $imageY >= $imageHeight) {
+	if (outsideImage( $imageX, $imageY )) {
 		# return $highSpeed;
 		return $lowSpeed;
 	}
 
- 	# return $highSpeed - $image->GetPixel(x=>$imageX, y=>$imageY)  * ($highSpeed - $lowSpeed);
- 	return $lowSpeed + $image->GetPixel(x=>$imageX, y=>$imageY)  * ($highSpeed - $lowSpeed);
+ 	# return $highSpeed - $image->GetPixel(x=>$imageX, y=>$imageY)  * $speedRange;
+ 	return $lowSpeed + $image->GetPixel(x=>$imageX, y=>$imageY)  * $speedRange;
 }
 
 sub outMove {

--- a/velPaint
+++ b/velPaint
@@ -6,6 +6,7 @@
 
 use strict;
 use warnings;
+use 5.10.1;
 
 our $VERSION = 0.1;
 use Math::Trig;
@@ -88,18 +89,11 @@ while (my $line = <>) {
 	chomp $line;
 	$line =~ s/\r//g;
 
-	($x, $y, $z, $e, $f) =
-	 $line =~ /G1 X(\S+) Y(\S+) Z(\S+) E(\S+) F($targetSpeed)$/;
-	($x, $y, $e, $f) =
-	 $line =~ /G1 X(\S+) Y(\S+) E(\S+) F($targetSpeed)$/ unless (defined $x);
-	($x, $y, $z, $e) =
-	 $line =~ /G1 X(\S+) Y(\S+) Z(\S+) E(\S+)$/ unless (defined $x);
-	($x, $y, $e) =
-	 $line =~ /G1 X(\S+) Y(\S+) E(\S+)$/ unless (defined $x);
-	($z, $x, $y, $e, $f) =
-	 $line =~ /G1 Z(\S+) X(\S+) Y(\S+) E(\S+) F($targetSpeed)$/;
-	($z, $x, $y, $e) =
-	 $line =~ /G1 Z(\S+) X(\S+) Y(\S+) E(\S+)$/ unless (defined $x);
+	if($line =~ /G1 X(?<x>\S+) Y(?<y>\S+)(?: Z(?<z>\S+))? E(?<e>\S+)(?: F(?<f>$targetSpeed))?$/ ||
+	  $line =~ /G1 Z(?<z>\S+) X(?<x>\S+) Y(?<y>\S+) E(?<e>\S+)(?: F(?<f>$targetSpeed))?$/)
+	{
+		($x, $y, $z, $e, $f) = @+{qw/x y z e f/};
+	}
 
 	if (defined $z) { $currentZ = $z } else { $z = $currentZ; }
 


### PR DESCRIPTION
This PR fixes the line recognition code that was failing on slic3r vase-mode generated gcode files by allowing the Z coordinate to come first.

It also contains some changes to improve the perl code.

- Small changes to reflect current best practices for Perl 5 code.
- Improve regular expressions to use simpler character classes.

The final commit uses a perl 5.10 feature that reduces the long run of regular expression matches into a pair of expressions that should be easier to maintain.

If you would like me to break this PR into smaller pieces, let me know.